### PR TITLE
Add missing docker dependencies to run obs_deploy

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,8 @@
 FROM opensuse/tumbleweed
 
 RUN zypper --gpg-auto-import-keys refresh
-RUN zypper install -y openssh vim iputils
+RUN zypper install -y openssh vim iputils ruby2.7 ruby2.7-devel ruby2.7-rubygem-cheetah ruby2.7-rubygem-nokogiri 
+RUN gem install git_diff_parser dry-cli
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Trying to run obs_deploy from inside the docker container fail with some
dependencies missing.

I tried to use packaged dependencies when possible and gem dependencies
otherwise.
